### PR TITLE
Feature | Add `changesNotSentForReview` option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,10 @@ inputs:
   mappingFile:
     description: "The mapping.txt file used to de-obfuscate your stack traces from crash reports"
     required: false
+  changesNotSentForReview:
+    description: "The changesNotSentForReview option whether changes can be sent for review automatically or not"
+    required: false
+    default: 'false'
 outputs:
   internalSharingDownloadUrl:
     description: "The internal app sharing download url if track was 'internalsharing'"

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
   changesNotSentForReview:
     description: "The changesNotSentForReview option whether changes can be sent for review automatically or not"
     required: false
-    default: 'false'
+    default: 'true'
 outputs:
   internalSharingDownloadUrl:
     description: "The internal app sharing download url if track was 'internalsharing'"

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -83,8 +83,6 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
 
         // Commit the pending Edit
         core.info(`Committing the Edit`)
-        core.info(`With applicationId: ${options.applicationId}`)
-        core.info(`With changesNotSentForReview: ${options.changesNotSentForReview}`)
         const res = await androidPublisher.edits.commit({
             auth: options.auth,
             editId: appEdit.data.id!,

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -83,6 +83,8 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
 
         // Commit the pending Edit
         core.info(`Committing the Edit`)
+        core.debug(`With applicationId: ${options.applicationId}`)
+        core.debug(`With changesNotSentForReview: ${options.changesNotSentForReview}`)
         const res = await androidPublisher.edits.commit({
             auth: options.auth,
             editId: appEdit.data.id!,

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -28,6 +28,7 @@ export interface EditOptions {
     mappingFile?: string;
     name?: string;
     status?: string;
+    changesNotSentForReview?: boolean;
 }
 
 export async function uploadToPlayStore(options: EditOptions, releaseFiles: string[]): Promise<string | undefined> {
@@ -85,7 +86,8 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
         const res = await androidPublisher.edits.commit({
             auth: options.auth,
             editId: appEdit.data.id!,
-            packageName: options.applicationId
+            packageName: options.applicationId,
+            changesNotSentForReview: options.changesNotSentForReview,
         });
 
         // Simple check to see whether commit was successful

--- a/src/edits.ts
+++ b/src/edits.ts
@@ -83,8 +83,8 @@ export async function uploadToPlayStore(options: EditOptions, releaseFiles: stri
 
         // Commit the pending Edit
         core.info(`Committing the Edit`)
-        core.debug(`With applicationId: ${options.applicationId}`)
-        core.debug(`With changesNotSentForReview: ${options.changesNotSentForReview}`)
+        core.info(`With applicationId: ${options.applicationId}`)
+        core.info(`With changesNotSentForReview: ${options.changesNotSentForReview}`)
         const res = await androidPublisher.edits.commit({
             auth: options.auth,
             editId: appEdit.data.id!,

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ async function run() {
         const status = core.getInput('status', { required: false });
         const whatsNewDir = core.getInput('whatsNewDirectory', { required: false });
         const mappingFile = core.getInput('mappingFile', { required: false });
-        const changesNotSentForReview = core.getInput('changesNotSentForReview', { required: false }) === 'true' ? true : false;
+        const changesNotSentForReview = core.getBooleanInput('changesNotSentForReview', { required: false });
 
         // Validate that we have a service account json in some format
         if (!serviceAccountJson && !serviceAccountJsonRaw) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ async function run() {
         const status = core.getInput('status', { required: false });
         const whatsNewDir = core.getInput('whatsNewDirectory', { required: false });
         const mappingFile = core.getInput('mappingFile', { required: false });
+        const changesNotSentForReview = core.getInput('changesNotSentForReview', { required: false }) === 'true' ? true : false;
 
         // Validate that we have a service account json in some format
         if (!serviceAccountJson && !serviceAccountJsonRaw) {
@@ -116,6 +117,7 @@ async function run() {
             status: status,
             whatsNewDir: whatsNewDir,
             mappingFile: mappingFile,
+            changesNotSentForReview: changesNotSentForReview,
             name: releaseName
         }, validatedReleaseFiles);
 


### PR DESCRIPTION
During the new update of Android Publisher, new bundle uploading to Play Store need to set `changesNotSentForReview` param to true to successfully commit the change